### PR TITLE
Define Finch.Response and return it from Finch.request

### DIFF
--- a/lib/finch/conn.ex
+++ b/lib/finch/conn.ex
@@ -1,6 +1,7 @@
 defmodule Finch.Conn do
   @moduledoc false
 
+  alias Finch.Response
   alias Mint.HTTP
 
   def new(scheme, host, port, opts, parent) do
@@ -59,7 +60,7 @@ defmodule Finch.Conn do
   def request(conn, req, receive_timeout) do
     case HTTP.request(conn.mint, req.method, req.path, req.headers, req.body) do
       {:ok, mint, ref} ->
-        receive_response([], %{conn | mint: mint}, ref, %{}, receive_timeout)
+        receive_response([], %{conn | mint: mint}, ref, %Response{}, receive_timeout)
 
       {:error, mint, error} ->
         {:error, %{conn | mint: mint}, error}
@@ -85,12 +86,16 @@ defmodule Finch.Conn do
 
   defp receive_response([entry | entries], conn, ref, response, timeout) do
     case entry do
-      {kind, ^ref, value} when kind in [:status, :headers] ->
-        response = Map.put(response, kind, value)
+      {:status, ^ref, value} ->
+        response = %{response | status: value}
+        receive_response(entries, conn, ref, response, timeout)
+
+      {:headers, ^ref, value} ->
+        response = %{response | headers: value}
         receive_response(entries, conn, ref, response, timeout)
 
       {:data, ^ref, data} ->
-        response = Map.update(response, :data, data, &(&1 <> data))
+        response = append_data_chunk(response, data)
         receive_response(entries, conn, ref, response, timeout)
 
       {:done, ^ref} ->
@@ -99,5 +104,13 @@ defmodule Finch.Conn do
       {:error, ^ref, error} ->
         {:error, conn, error}
     end
+  end
+
+  defp append_data_chunk(%Response{body: nil} = response, data_chunk) do
+    %{response | body: data_chunk}
+  end
+
+  defp append_data_chunk(%Response{body: body} = response, data_chunk) when is_binary(body) do
+    %{response | body: body <> data_chunk}
   end
 end

--- a/lib/finch/response.ex
+++ b/lib/finch/response.ex
@@ -1,0 +1,40 @@
+defmodule Finch.Response do
+  @moduledoc """
+  A response to a request.
+  """
+
+  alias __MODULE__
+
+  defstruct [
+    :status,
+    :body,
+    headers: []
+  ]
+
+  @typedoc """
+  An HTTP status code.
+
+  The type for an HTTP is a generic non-negative integer since we don't formally check that
+  the response code is in the "common" range (`200..599`).
+  """
+  @type status() :: non_neg_integer()
+
+  @typedoc """
+  A body associated with a response.
+  """
+  @type body() :: binary() | nil
+
+  @typedoc """
+  HTTP response headers.
+
+  Headers are received as lists of two-element tuples containing two strings,
+  the header name and header value.
+  """
+  @type headers() :: [{header_name :: String.t(), header_value :: String.t()}]
+
+  @type t :: %Response{
+          status: status(),
+          body: body(),
+          headers: headers()
+        }
+end

--- a/test/finch_test.exs
+++ b/test/finch_test.exs
@@ -2,6 +2,8 @@ defmodule FinchTest do
   use ExUnit.Case, async: true
   doctest Finch
 
+  alias Finch.Response
+
   setup do
     {:ok, bypass: Bypass.open()}
   end
@@ -18,21 +20,21 @@ defmodule FinchTest do
       start_supervised({Finch, name: MyFinch})
       expect_any(bypass)
 
-      {:ok, _response} = Finch.request(MyFinch, :get, endpoint(bypass), [], "")
+      {:ok, %Response{}} = Finch.request(MyFinch, :get, endpoint(bypass), [], "")
       assert [_pool] = get_pools(MyFinch, shp(bypass))
 
-      {:ok, _response} = Finch.request(MyFinch, :get, endpoint(bypass), [], "")
+      {:ok, %Response{}} = Finch.request(MyFinch, :get, endpoint(bypass), [], "")
     end
 
     test "default can be configured", %{bypass: bypass} do
       {:ok, _} = Finch.start_link(name: MyFinch, pools: %{default: %{count: 5, size: 5}})
       expect_any(bypass)
 
-      {:ok, _response} = Finch.request(MyFinch, "GET", endpoint(bypass), [], "")
+      {:ok, %Response{}} = Finch.request(MyFinch, "GET", endpoint(bypass), [], "")
       pools = get_pools(MyFinch, shp(bypass))
       assert length(pools) == 5
 
-      {:ok, _response} = Finch.request(MyFinch, "GET", endpoint(bypass), [], "")
+      {:ok, %Response{}} = Finch.request(MyFinch, "GET", endpoint(bypass), [], "")
     end
 
     test "specific scheme, host, port combos can be configurated independently and pools will be started automatically",
@@ -74,7 +76,7 @@ defmodule FinchTest do
         |> Plug.Conn.send_resp(200, response_body)
       end)
 
-      assert {:ok, %{status: 200, headers: headers, data: ^response_body}} =
+      assert {:ok, %Response{status: 200, headers: headers, body: ^response_body}} =
                Finch.request(
                  MyFinch,
                  :post,
@@ -99,7 +101,7 @@ defmodule FinchTest do
         |> Plug.Conn.send_resp(200, "OK")
       end)
 
-      assert {:ok, %{status: 200, data: "OK"}} =
+      assert {:ok, %Response{status: 200, body: "OK"}} =
                Finch.request(
                  MyFinch,
                  :get,
@@ -121,7 +123,7 @@ defmodule FinchTest do
       assert {:error, %{reason: :timeout}} =
                Finch.request(MyFinch, :get, endpoint(bypass), [], nil, receive_timeout: timeout)
 
-      assert {:ok, _} =
+      assert {:ok, %Response{}} =
                Finch.request(MyFinch, :get, endpoint(bypass), [], nil,
                  receive_timeout: timeout * 2
                )
@@ -132,7 +134,7 @@ defmodule FinchTest do
       expect_any(bypass)
 
       timeout = 100
-      {:ok, _} = Finch.request(MyFinch, :get, endpoint(bypass))
+      {:ok, %Response{}} = Finch.request(MyFinch, :get, endpoint(bypass))
 
       Bypass.down(bypass)
 
@@ -144,7 +146,7 @@ defmodule FinchTest do
       end
 
       Bypass.up(bypass)
-      assert {:ok, _} = Finch.request(MyFinch, :get, endpoint(bypass))
+      assert {:ok, %Response{}} = Finch.request(MyFinch, :get, endpoint(bypass))
     end
   end
 


### PR DESCRIPTION
This resolves #5 

Thanks for making some issues on the repo! This issue seemed pretty trivial, so I thought I'd start here :)

I grabbed the typespecs from [Mint](https://github.com/elixir-mint/mint/blob/master/lib/mint/types.ex) to make sure they align with the types in `Finch.Response`.

I did not enforce any of the fields on the struct, because we receive the fields one at a time. If you'd like to enforce the fields on the struct, I'm happy to defer construction of the struct until we process the `:done` message.

In the case of `:data`, I defaulted to `""` because I think it makes for a cleaner API, but I understand if this is a controversial choice, and you'd prefer to be able to distinguish between an empty body, and no body.

Regardless, I'm happy to make any changes. I tried to stick to existing coding style where possible, but since the project is fairly small still, I wasn't sure where you stand on things like `alias __MODULE__`