### PR TITLE
Make sure we do not lose the request query string

### DIFF
--- a/lib/finch.ex
+++ b/lib/finch.ex
@@ -110,7 +110,8 @@ defmodule Finch do
       method: build_method(method),
       path: uri.path || "/",
       headers: headers,
-      body: body
+      body: body,
+      query: uri.query
     }
 
     pool = PoolManager.get_pool(name, req.scheme, req.host, req.port)


### PR DESCRIPTION
During testing I noticed that my query string params were not being sent :)