### PR TITLE
Remove unused error clause in Finch.Pool.request/3

### DIFF
--- a/lib/finch/pool.ex
+++ b/lib/finch/pool.ex
@@ -32,9 +32,6 @@ defmodule Finch.Pool do
 
           {:error, conn, error} ->
             {{:error, error}, conn}
-
-          {:error, error} ->
-            {{:error, error}, conn}
         end
       end,
       pool_timeout


### PR DESCRIPTION
Finch.Conn.request/3 only returns error tuples of the form: `{:error, %Conn{}, term}`