### PR TITLE
CI caching

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -14,6 +14,18 @@ jobs:
    runs-on: ubuntu-16.04
    steps:
      - uses: actions/checkout@v2
+     - uses: actions/cache@v1
+       with:
+         path: deps
+         key: ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-mix-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
+         restore-keys: |
+           ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-
+     - uses: actions/cache@v1
+       with:
+         path: _build
+         key: ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-build-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
+         restore-keys: |
+           ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-
      - uses: actions/setup-elixir@v1
        with:
          otp-version: ${{ matrix.otp }}

--- a/README.md
+++ b/README.md
@@ -19,3 +19,4 @@ Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_do
 and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
 be found at [https://hexdocs.pm/finch](https://hexdocs.pm/finch).
 
+


### PR DESCRIPTION
Reduces build time from > 2 minutes, to ~30 seconds
<img width="934" alt="Screen Shot 2020-04-09 at 14 09 30" src="https://user-images.githubusercontent.com/7762396/78893523-c6958b00-7a6b-11ea-89c1-472dd799c7d4.png">
