### PR TITLE
Suggestions on how to move to NimblePool master with precheckin

### DIFF
--- a/lib/finch/pool.ex
+++ b/lib/finch/pool.ex
@@ -81,8 +81,9 @@ defmodule Finch.Pool do
   end
 
   @impl NimblePool
-  def handle_checkin(conn, _from, _old_conn) do
-    with {:ok, conn} <- Conn.set_mode(conn, :active) do
+  def handle_checkin(state, _from, conn) do
+    with :prechecked <- state,
+         {:ok, conn} <- Conn.set_mode(conn, :active) do
       {:ok, conn}
     else
       _ ->
@@ -120,8 +121,10 @@ defmodule Finch.Pool do
         {:ok, _} -> conn
         {:error, _} -> Conn.close(conn)
       end
+      
+      :prechecked
+    else
+      :closed
     end
-
-    conn
   end
 end


### PR DESCRIPTION
So I pushed a commit to NimblePool that adds precheckin. This is a small POC on how to move to NimblePool master.

The PR is incomplete as it doesn't change the `mix.exs` and I have a refactoring suggestion. I think it would be ideal if Conn.transfer simply returned `:ok`. I will send a PR to Mint to document the returned `conn` from HTTP.controlling_process does not matter.

### Explanation

The current Finch implementation has a port leak. My hypothesis is that the port leak is caused by this code:

    {:ok, conn} = Conn.transfer(conn, pool)
    send(parent, {:checkin, conn})

The issue is that we transfer the connection and then checkin. However, if the process terminates before we checkin, then the pool has the connection but it doesn't know about it.

With my changes above, we do this:

    send(parent, {:precheckin, conn})
    {:ok, _} = Conn.transfer(conn, pool)
    send(parent, {:checkin, :prechecked})

So we transfer the connection before hand. If for some reason the transfer fails, we will checkin with a connection we don't own. Checkin will then fail and remove the connection.

If the client dies before checking in, then we already have the updated connection, meaning we will call `terminate` and close the connection.

Therefore, this approach guarantees we always close the connection.