### PR TITLE
Emit :handle_checkout events with idle_time measurements

### DIFF
--- a/lib/finch/conn.ex
+++ b/lib/finch/conn.ex
@@ -12,6 +12,7 @@ defmodule Finch.Conn do
       port: port,
       opts: opts.conn_opts,
       parent: parent,
+      last_checkin: System.monotonic_time(),
       mint: nil
     }
   end

--- a/lib/finch/telemetry.ex
+++ b/lib/finch/telemetry.ex
@@ -23,6 +23,7 @@ defmodule Finch.Telemetry do
     #### Measurements
 
     * `:duration` - Duration to check out a pool connection.
+    * `:idle_time` - Elapsed time since the connection was last checked in or initialized.
 
     #### Metadata
 
@@ -123,12 +124,12 @@ defmodule Finch.Telemetry do
 
   @doc false
   # emits a `start` telemetry event and returns the the start time
-  def start(event, meta \\ %{}) do
+  def start(event, meta \\ %{}, extra_measurements \\ %{}) do
     start_time = System.monotonic_time()
 
     :telemetry.execute(
       [:finch, event, :start],
-      %{system_time: System.system_time()},
+      Map.merge(extra_measurements, %{system_time: System.system_time()}),
       meta
     )
 
@@ -137,9 +138,9 @@ defmodule Finch.Telemetry do
 
   @doc false
   # Emits a stop event.
-  def stop(event, start_time, meta \\ %{}) do
+  def stop(event, start_time, meta \\ %{}, extra_measurements \\ %{}) do
     end_time = System.monotonic_time()
-    measurements = %{duration: end_time - start_time}
+    measurements = Map.merge(extra_measurements, %{duration: end_time - start_time})
 
     :telemetry.execute(
       [:finch, event, :stop],
@@ -149,9 +150,9 @@ defmodule Finch.Telemetry do
   end
 
   @doc false
-  def exception(event, start_time, kind, reason, stack, meta \\ %{}) do
+  def exception(event, start_time, kind, reason, stack, meta \\ %{}, extra_measurements \\ %{}) do
     end_time = System.monotonic_time()
-    measurements = %{duration: end_time - start_time}
+    measurements = Map.merge(extra_measurements, %{duration: end_time - start_time})
 
     meta =
       meta

--- a/test/finch_test.exs
+++ b/test/finch_test.exs
@@ -319,6 +319,7 @@ defmodule FinchTest do
 
           [:finch, :queue, :stop] ->
             assert is_integer(measurements.duration)
+            assert is_integer(measurements.idle_time)
             assert is_pid(meta.pool)
             assert is_atom(meta.scheme)
             assert is_integer(meta.port)


### PR DESCRIPTION
Closes #27 

The issue mentions possibly tracking "first_use_time" separately, but I think this measurement alone should suit our needs for now.