### PR TITLE
Allow arbitrary string methods to be used

### DIFF
--- a/lib/finch.ex
+++ b/lib/finch.ex
@@ -131,15 +131,14 @@ defmodule Finch do
   end
 
   defp build_method(method) when is_binary(method), do: method
-
-  defp build_method(method) when is_atom(method) and method in @atom_methods do
-    @atom_to_method[method]
-  end
+  defp build_method(method) when method in @atom_methods, do: @atom_to_method[method]
 
   defp build_method(method) do
     raise ArgumentError, """
     got unsupported atom method #{inspect(method)}.
-    only the following methods can be provided as atoms: #{Enum.map_join(@atom_methods, ", ", &inspect/1)}",
+    only the following methods can be provided as atoms: #{
+      Enum.map_join(@atom_methods, ", ", &inspect/1)
+    }",
     otherwise you must pass a binary.
     """
   end

--- a/lib/finch.ex
+++ b/lib/finch.ex
@@ -130,10 +130,18 @@ defmodule Finch do
     end
   end
 
-  defp build_method(method) when method in @methods, do: method
+  defp build_method(method) when is_binary(method), do: method
 
-  defp build_method(method) when is_atom(method) do
+  defp build_method(method) when is_atom(method) and method in @atom_methods do
     @atom_to_method[method]
+  end
+
+  defp build_method(method) do
+    raise ArgumentError, """
+    got unsupported atom method #{inspect(method)}.
+    only the following methods can be provided as atoms: #{Enum.join(@atom_methods, ", ")}",
+    otherwise you must pass a binary.
+    """
   end
 
   defp normalize_scheme(scheme) do
@@ -158,7 +166,8 @@ defmodule Finch do
         Map.put(acc, valid_destination, valid_pool_opts)
       else
         {:error, reason} ->
-          raise ArgumentError, "got invalid configuration for pool #{destination}! #{reason}"
+          raise ArgumentError,
+                "got invalid configuration for pool #{inspect(destination)}! #{reason}"
       end
     end)
   end

--- a/lib/finch.ex
+++ b/lib/finch.ex
@@ -139,7 +139,7 @@ defmodule Finch do
   defp build_method(method) do
     raise ArgumentError, """
     got unsupported atom method #{inspect(method)}.
-    only the following methods can be provided as atoms: #{Enum.join(@atom_methods, ", ")}",
+    only the following methods can be provided as atoms: #{Enum.map_join(@atom_methods, ", ", &inspect/1)}",
     otherwise you must pass a binary.
     """
   end

--- a/test/finch_test.exs
+++ b/test/finch_test.exs
@@ -10,8 +10,7 @@ defmodule FinchTest do
 
   describe "start_link/1" do
     test "raises if :name is not provided" do
-      error = assert_raise(ArgumentError, fn -> Finch.start_link([]) end)
-      assert error.message =~ "must supply a name"
+      assert_raise(ArgumentError, ~r/must supply a name/, fn -> Finch.start_link([]) end)
     end
   end
 
@@ -41,19 +40,13 @@ defmodule FinchTest do
     end
 
     test "raises when invalid configuration is provided" do
-      error =
-        assert_raise(ArgumentError, fn ->
-          Finch.start_link(name: MyFinch, pools: %{default: [count: :dog]})
-        end)
+      assert_raise(ArgumentError, ~r/got invalid configuration/, fn ->
+        Finch.start_link(name: MyFinch, pools: %{default: [count: :dog]})
+      end)
 
-      assert error.message =~ "got invalid configuration"
-
-      error =
-        assert_raise(ArgumentError, fn ->
-          Finch.start_link(name: MyFinch, pools: %{invalid: [count: 5, size: 5]})
-        end)
-
-      assert error.message =~ "invalid destination"
+      assert_raise(ArgumentError, ~r/invalid destination/, fn ->
+        Finch.start_link(name: MyFinch, pools: %{invalid: [count: 5, size: 5]})
+      end)
     end
 
     test "pools are started based on only the {scheme, host, port} of the URLs",
@@ -78,41 +71,32 @@ defmodule FinchTest do
     end
 
     test "pools with an invalid URL cannot be started" do
-      error =
-        assert_raise(ArgumentError, fn ->
-          Finch.start_link(
-            name: MyFinch,
-            pools: %{
-              "example.com" => [count: 5, size: 5]
-            }
-          )
-        end)
+      assert_raise(ArgumentError, ~r/invalid scheme nil/, fn ->
+        Finch.start_link(
+          name: MyFinch,
+          pools: %{
+            "example.com" => [count: 5, size: 5]
+          }
+        )
+      end)
 
-      assert error.message =~ "invalid scheme nil"
+      assert_raise(ArgumentError, ~r/invalid scheme nil/, fn ->
+        Finch.start_link(
+          name: MyFinch,
+          pools: %{
+            "example" => [count: 5, size: 5]
+          }
+        )
+      end)
 
-      error =
-        assert_raise(ArgumentError, fn ->
-          Finch.start_link(
-            name: MyFinch,
-            pools: %{
-              "example" => [count: 5, size: 5]
-            }
-          )
-        end)
-
-      assert error.message =~ "invalid scheme nil"
-
-      error =
-        assert_raise(ArgumentError, fn ->
-          Finch.start_link(
-            name: MyFinch,
-            pools: %{
-              ":443" => [count: 5, size: 5]
-            }
-          )
-        end)
-
-      assert error.message =~ "invalid scheme nil"
+      assert_raise(ArgumentError, ~r/invalid scheme nil/, fn ->
+        Finch.start_link(
+          name: MyFinch,
+          pools: %{
+            ":443" => [count: 5, size: 5]
+          }
+        )
+      end)
     end
 
     test "impossible to accidentally start multiple pools when they are dynamically started", %{

--- a/test/finch_test.exs
+++ b/test/finch_test.exs
@@ -186,10 +186,9 @@ defmodule FinchTest do
     end
 
     test "raises if unsupported atom request method provided", %{bypass: bypass} do
-      error =
-        assert_raise(ArgumentError, fn -> Finch.request(MyFinch, :gimme, endpoint(bypass)) end)
-
-      assert error.message =~ "got unsupported atom method :gimme"
+      assert_raise ArgumentError, ~r/got unsupported atom method :gimme/, fn ->
+        Finch.request(MyFinch, :gimme, endpoint(bypass))
+      end
     end
 
     test "raises when requesting a URL with an invalid scheme" do

--- a/test/finch_test.exs
+++ b/test/finch_test.exs
@@ -137,7 +137,7 @@ defmodule FinchTest do
     end
   end
 
-  describe "request/5" do
+  describe "request/6" do
     test "successful get request, with query string", %{bypass: bypass} do
       start_supervised({Finch, name: MyFinch})
       query_string = "query=value"
@@ -183,6 +183,13 @@ defmodule FinchTest do
                  {"content-type", _} -> true
                  _ -> false
                end)
+    end
+
+    test "raises if unsupported atom request method provided", %{bypass: bypass} do
+      error =
+        assert_raise(ArgumentError, fn -> Finch.request(MyFinch, :gimme, endpoint(bypass)) end)
+
+      assert error.message =~ "got unsupported atom method :gimme"
     end
 
     test "raises when requesting a URL with an invalid scheme" do


### PR DESCRIPTION
Closes #40 

Unfortunately, I don't think I can write a test for non standard HTTP methods using bypass, as the [Plug.Router](https://github.com/elixir-plug/plug/blob/8efb591f53c87c51a9aded8212daa78e7c3ff83e/lib/plug/router.ex#L47) only supports the standard ones.

Either way, we will need a new test server once we introduce HTTP/2 support, so I will begin looking in to a custom HTTP/1 test server now as well.