### PR TITLE
Return empty string for missing response bodies

### DIFF
--- a/lib/finch/http1/conn.ex
+++ b/lib/finch/http1/conn.ex
@@ -163,10 +163,6 @@ defmodule Finch.Conn do
     end
   end
 
-  defp append_data_chunk(%Response{body: nil} = response, data_chunk) do
-    %{response | body: data_chunk}
-  end
-
   defp append_data_chunk(%Response{body: body} = response, data_chunk) when is_binary(body) do
     %{response | body: body <> data_chunk}
   end

--- a/lib/finch/response.ex
+++ b/lib/finch/response.ex
@@ -7,18 +7,13 @@ defmodule Finch.Response do
 
   defstruct [
     :status,
-    :body,
+    body: "",
     headers: []
   ]
 
-  @typedoc """
-  A body associated with a response.
-  """
-  @type body() :: binary() | nil
-
   @type t :: %Response{
           status: Mint.Types.status(),
-          body: body(),
+          body: binary(),
           headers: Mint.Types.headers()
         }
 end


### PR DESCRIPTION
So, after using starting to roll this out into production I've received a bunch of feedback that we should default the response body to an empty string. After thinking about it more I think that is probably the correct choice for a few reasons:

* It's not "wrong" semantically speaking. This is the most important point IMO. From the point of view of the parser, we'd expect it to return something like an empty string.
* It removes additional error checking logic that users need to do.
* There's a precedent for this in elixir already. The other clients return empty strings.
* Clients in other languages also use an empty string. I had only glanced at the ruby client. At this point, I'm pretty sure ruby is the outlier here.

That's my reasoning for making this change now.

TL;DR - @QuinnWilton was right :heart: