### PR TITLE
Use __STACKTRACE__ instead of System.stacktrace()

### DIFF
--- a/lib/finch/http1/pool.ex
+++ b/lib/finch/http1/pool.ex
@@ -51,7 +51,7 @@ defmodule Finch.HTTP1.Pool do
       )
     catch
       :exit, data ->
-        Telemetry.exception(:queue, start_time, :exit, data, System.stacktrace(), metadata)
+        Telemetry.exception(:queue, start_time, :exit, data, __STACKTRACE__, metadata)
         exit(data)
     end
   end


### PR DESCRIPTION
Starting with OTP 23 `erlang:get_stacktrace/0` and thus `System.stacktrace/0` will always return an empty list.