### PR TITLE
Add streaming support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Once you have started Finch, you can use the client you have started,
 by passing the name of your client as the first argument of `Finch.request/3,4,5,6`:
 
 ```elixir
-Finch.request(MyFinch, :get, "https://hex.pm")
+Finch.build(:get, "https://hex.pm") |> Finch.request(MyFinch)
 ```
 
 When using HTTP/1, Finch will parse the passed in URL into a `{scheme, host, port}`

--- a/lib/finch.ex
+++ b/lib/finch.ex
@@ -150,7 +150,6 @@ defmodule Finch do
   @spec build(Request.method(), Request.url(), Request.headers(), Request.body()) :: Request.t()
   defdelegate build(method, url, headers \\ [], body \\ nil), to: Request
 
-
   @doc """
   Streams an HTTP request and returns the accumulator.
 

--- a/lib/finch.ex
+++ b/lib/finch.ex
@@ -5,29 +5,10 @@ defmodule Finch do
              |> String.split("<!-- MDOC !-->")
              |> Enum.fetch!(1)
 
-  alias Finch.PoolManager
+  alias Finch.{PoolManager, Request}
 
   use Supervisor
 
-  @atom_methods [
-    :get,
-    :post,
-    :put,
-    :patch,
-    :delete,
-    :head,
-    :options
-  ]
-  @methods [
-    "GET",
-    "POST",
-    "PUT",
-    "PATCH",
-    "DELETE",
-    "HEAD",
-    "OPTIONS"
-  ]
-  @atom_to_method Enum.zip(@atom_methods, @methods) |> Enum.into(%{})
   @default_pool_size 10
   @default_pool_count 1
 
@@ -61,27 +42,16 @@ defmodule Finch do
   @type name() :: atom()
 
   @typedoc """
-  An HTTP request method represented as an `atom()` or a `String.t()`.
-
-  The following atom methods are supported: `#{Enum.map_join(@atom_methods, "`, `", &inspect/1)}`.
-  You can use any arbitrary method by providing it as a `String.t()`.
+  The stream function given to `stream/5`.
   """
-  @type http_method() :: :get | :post | :head | :patch | :delete | :options | :put | String.t()
-
-  @typedoc """
-  A Uniform Resource Locator, the address of a resource on the Web.
-  """
-  @type url() :: String.t() | URI.t()
-
-  @typedoc """
-  A body associated with a request.
-  """
-  @type body() :: iodata() | nil
+  @type stream(acc) ::
+          ({:status, integer} | {:headers, Mint.Types.headers()} | {:data, binary}, acc -> acc)
 
   @doc """
   Start an instance of Finch.
 
-  ## Options:
+  ## Options
+
     * `:name` - The name of your Finch instance. This field is required.
 
     * `:pools` - A map specifying the configuration for your pools. The keys should be URLs
@@ -92,6 +62,7 @@ defmodule Finch do
   }]}`.
 
   ### Pool Configuration Options
+
   #{NimbleOptions.docs(@pool_config_schema)}
   """
   def start_link(opts) do
@@ -119,93 +90,6 @@ defmodule Finch do
     ]
 
     Supervisor.init(children, strategy: :one_for_all)
-  end
-
-  @doc """
-  Sends an HTTP request and returns the response.
-
-  ## Options:
-
-    * `:pool_timeout` - This timeout is applied when we check out a connection from the pool.
-      Default value is `5_000`.
-
-    * `:receive_timeout` - The maximum time to wait for a response before returning an error.
-      Default value is `5_000`.
-  """
-  @spec request(name(), http_method(), url(), Mint.Types.headers(), body(), keyword()) ::
-          {:ok, Finch.Response.t()} | {:error, Mint.Types.error()}
-  def request(name, method, url, headers \\ [], body \\ nil, opts \\ []) do
-    with {:ok, uri} <- parse_and_normalize_url(url) do
-      req = %{
-        scheme: uri.scheme,
-        host: uri.host,
-        port: uri.port,
-        method: build_method(method),
-        path: uri.path,
-        headers: headers,
-        body: body,
-        query: uri.query
-      }
-
-      opts = Keyword.merge([receive_timeout: 5_000], opts)
-
-      shp = {uri.scheme, uri.host, uri.port}
-
-      {pool, pool_mod} = PoolManager.get_pool(name, shp)
-      pool_mod.request(pool, req, opts)
-    end
-  end
-
-  defp parse_and_normalize_url(url) when is_binary(url) do
-    url
-    |> URI.parse()
-    |> parse_and_normalize_url()
-  end
-
-  defp parse_and_normalize_url(%URI{} = parsed_uri) do
-    normalize_uri(parsed_uri)
-  end
-
-  defp normalize_uri(parsed_uri) do
-    normalized_path = parsed_uri.path || "/"
-
-    with {:ok, scheme} <- normalize_scheme(parsed_uri.scheme) do
-      normalized_uri = %{
-        scheme: scheme,
-        host: parsed_uri.host,
-        port: parsed_uri.port,
-        path: normalized_path,
-        query: parsed_uri.query
-      }
-
-      {:ok, normalized_uri}
-    end
-  end
-
-  defp build_method(method) when is_binary(method), do: method
-  defp build_method(method) when method in @atom_methods, do: @atom_to_method[method]
-
-  defp build_method(method) do
-    raise ArgumentError, """
-    got unsupported atom method #{inspect(method)}.
-    only the following methods can be provided as atoms: #{
-      Enum.map_join(@atom_methods, ", ", &inspect/1)
-    }",
-    otherwise you must pass a binary.
-    """
-  end
-
-  defp normalize_scheme(scheme) do
-    case scheme do
-      "https" ->
-        {:ok, :https}
-
-      "http" ->
-        {:ok, :http}
-
-      scheme ->
-        {:error, "invalid scheme #{inspect(scheme)}"}
-    end
   end
 
   defp pool_options!(pools) do
@@ -237,10 +121,8 @@ defmodule Finch do
   end
 
   defp cast_binary_destination(url) when is_binary(url) do
-    with {:ok, uri} <- parse_and_normalize_url(url),
-         shp <- {uri.scheme, uri.host, uri.port} do
-      {:ok, shp}
-    end
+    {scheme, host, port, _path, _query} = Finch.Request.parse_url(url)
+    {:ok, {scheme, host, port}}
   end
 
   defp cast_pool_opts(opts) do
@@ -261,4 +143,88 @@ defmodule Finch do
   defp supervisor_name(name), do: :"#{name}.Supervisor"
   defp manager_name(name), do: :"#{name}.PoolManager"
   defp pool_supervisor_name(name), do: :"#{name}.PoolSupervisor"
+
+  @doc """
+  Builds an HTTP request to be sent with `request/3` or `stream/4`.
+  """
+  @spec build(Request.method(), Request.url(), Request.headers(), Request.body()) :: Request.t()
+  defdelegate build(method, url, headers \\ [], body \\ nil), to: Request
+
+
+  @doc """
+  Streams an HTTP request and returns the accumulator.
+
+  A function of arity 2 is expected as argument. The first argument
+  is a tuple, as listed below, and the second argument is the
+  accumulator. The function must return a potentially updated
+  accumulator.
+
+  ## Stream commands
+
+    * `{:status, status}` - the status of the http response
+    * `{:headers, headers}` - the headers of the http response
+    * `{:data, data}` - a streaming section of the http body
+
+  ## Options
+
+    * `:pool_timeout` - This timeout is applied when we check out a connection from the pool.
+      Default value is `5_000`.
+
+    * `:receive_timeout` - The maximum time to wait for a response before returning an error.
+      Default value is `15_000`.
+
+  """
+  @spec stream(Request.t(), name(), acc, stream(acc), keyword) :: Request.t() when acc: term()
+  def stream(%Request{} = req, name, acc, fun, opts \\ []) when is_function(fun, 2) do
+    %{scheme: scheme, host: host, port: port} = req
+    {pool, pool_mod} = PoolManager.get_pool(name, {scheme, host, port})
+    pool_mod.request(pool, req, acc, fun, opts)
+  end
+
+  @doc """
+  Sends an HTTP request and returns a `Finch.Response` struct.
+
+  ## Options
+
+    * `:pool_timeout` - This timeout is applied when we check out a connection from the pool.
+      Default value is `5_000`.
+
+    * `:receive_timeout` - The maximum time to wait for a response before returning an error.
+      Default value is `15_000`.
+
+  """
+  @spec request(Request.t(), name(), keyword()) ::
+          {:ok, Finch.Response.t()} | {:error, Mint.Types.error()}
+  def request(req, name, opts \\ [])
+
+  def request(%Request{} = req, name, opts) do
+    acc = {nil, [], []}
+
+    fun = fn
+      {:status, value}, {_, headers, body} -> {value, headers, body}
+      {:headers, value}, {status, headers, body} -> {status, headers ++ value, body}
+      {:data, value}, {status, headers, body} -> {status, headers, [value | body]}
+    end
+
+    with {:ok, {status, headers, body}} <- stream(req, name, acc, fun, opts) do
+      {:ok,
+       %Finch.Response{
+         status: status,
+         headers: headers,
+         body: body |> Enum.reverse() |> IO.iodata_to_binary()
+       }}
+    end
+  end
+
+  # Catch-all for backwards compatibility below
+  def request(name, method, url) do
+    request(name, method, url, [])
+  end
+
+  def request(name, method, url, headers, body \\ nil, opts \\ []) do
+    IO.warn("Finch.request/6 is deprecated, use Finch.build/4 + Finch.request/3 instead")
+
+    build(method, url, headers, body)
+    |> request(name, opts)
+  end
 end

--- a/lib/finch/http1/pool.ex
+++ b/lib/finch/http1/pool.ex
@@ -19,7 +19,7 @@ defmodule Finch.HTTP1.Pool do
   end
 
   @impl Finch.Pool
-  def request(pool, req, opts) do
+  def request(pool, req, acc, fun, opts) do
     pool_timeout = Keyword.get(opts, :pool_timeout, 5_000)
     receive_timeout = Keyword.get(opts, :receive_timeout, 15_000)
 
@@ -40,8 +40,8 @@ defmodule Finch.HTTP1.Pool do
           Telemetry.stop(:queue, start_time, metadata, %{idle_time: idle_time})
 
           with {:ok, conn} <- Conn.connect(conn),
-               {:ok, conn, response} <- Conn.request(conn, req, receive_timeout) do
-            {{:ok, response}, transfer_if_open(conn, from)}
+               {:ok, conn, acc} <- Conn.request(conn, req, acc, fun, receive_timeout) do
+            {{:ok, acc}, transfer_if_open(conn, from)}
           else
             {:error, conn, error} ->
               {{:error, error}, transfer_if_open(conn, from)}

--- a/lib/finch/http2/pool.ex
+++ b/lib/finch/http2/pool.ex
@@ -2,15 +2,15 @@ defmodule Finch.HTTP2.Pool do
   @moduledoc false
 
   @behaviour :gen_statem
+  @behaviour Finch.Pool
 
   alias Mint.HTTP2
   alias Mint.HTTPError
-  alias Finch.Response
   alias Finch.Telemetry
 
   require Logger
 
-  @default_receive_timeout 1_000
+  @default_receive_timeout 15000
 
   @impl true
   def callback_mode(), do: [:state_functions, :state_enter]
@@ -24,7 +24,8 @@ defmodule Finch.HTTP2.Pool do
 
   # Call the pool with the request. The pool will multiplex multiple requests
   # and stream the result set back to the calling process using `send`
-  def request(pool, request, opts) do
+  @impl true
+  def request(pool, request, acc, fun, opts) do
     opts = Keyword.put_new(opts, :receive_timeout, @default_receive_timeout)
     timeout = opts[:receive_timeout]
 
@@ -32,7 +33,7 @@ defmodule Finch.HTTP2.Pool do
       scheme: request.scheme,
       host: request.host,
       port: request.port,
-      path: request_path(request)
+      path: Finch.Request.request_path(request)
     }
 
     start_time = Telemetry.start(:request, metadata)
@@ -48,7 +49,7 @@ defmodule Finch.HTTP2.Pool do
       fail_safe_timeout = if is_integer(timeout), do: max(2000, timeout * 2), else: :infinity
       start_time = Telemetry.start(:response, metadata)
       try do
-        result = response_waiting_loop(ref, monitor, %Response{}, fail_safe_timeout)
+        result = response_waiting_loop(acc, fun, ref, monitor, fail_safe_timeout)
 
         case result do
           {:ok, _} ->
@@ -68,21 +69,16 @@ defmodule Finch.HTTP2.Pool do
     end
   end
 
-  defp response_waiting_loop(ref, monitor_ref, response, fail_safe_timeout) do
+  defp response_waiting_loop(acc, fun, ref, monitor_ref, fail_safe_timeout) do
     receive do
       {:DOWN, ^monitor_ref, _, _, _} ->
         {:error, :connection_process_went_down}
 
-      {kind, ^ref, value} when kind in [:status, :headers] ->
-        response = Map.put(response, kind, value)
-        response_waiting_loop(ref, monitor_ref, response, fail_safe_timeout)
-
-      {:data, ^ref, data} ->
-        response = Map.update(response, :body, data, &(&1 <> data))
-        response_waiting_loop(ref, monitor_ref, response, fail_safe_timeout)
+      {kind, ^ref, value} when kind in [:status, :headers, :data] ->
+        response_waiting_loop(fun.({kind, value}, acc), fun, ref, monitor_ref, fail_safe_timeout)
 
       {:done, _ref} ->
-        {:ok, response}
+        {:ok, acc}
 
       {:error, ^ref, error} ->
         {:error, error}
@@ -403,7 +399,4 @@ defmodule Finch.HTTP2.Pool do
     max_sleep = trunc(min(max_backoff, base_backoff * factor))
     :rand.uniform(max_sleep)
   end
-
-  defp request_path(%{path: path, query: nil}), do: path
-  defp request_path(%{path: path, query: query}), do: "#{path}?#{query}"
 end

--- a/lib/finch/http2/pool.ex
+++ b/lib/finch/http2/pool.ex
@@ -10,7 +10,7 @@ defmodule Finch.HTTP2.Pool do
 
   require Logger
 
-  @default_receive_timeout 15000
+  @default_receive_timeout 15_000
 
   @impl true
   def callback_mode(), do: [:state_functions, :state_enter]

--- a/lib/finch/pool.ex
+++ b/lib/finch/pool.ex
@@ -1,6 +1,7 @@
 defmodule Finch.Pool do
   @moduledoc false
   # Defines a behaviour that both http1 and http2 pools need to implement.
-
-  @callback request(pid(), map(), list()) :: {:ok, Finch.Response.t()} | {:error, term()}
+  @callback request(pid(), Finch.Request.t(), acc, Finch.stream(acc), list()) ::
+              {:ok, acc} | {:error, term()}
+            when acc: term()
 end

--- a/lib/finch/request.ex
+++ b/lib/finch/request.ex
@@ -1,0 +1,114 @@
+defmodule Finch.Request do
+  @moduledoc """
+  A request struct.
+  """
+
+  @enforce_keys [:scheme, :host, :port, :method, :path, :headers, :body, :query]
+  defstruct [:scheme, :host, :port, :method, :path, :headers, :body, :query]
+
+  @atom_methods [
+    :get,
+    :post,
+    :put,
+    :patch,
+    :delete,
+    :head,
+    :options
+  ]
+  @methods [
+    "GET",
+    "POST",
+    "PUT",
+    "PATCH",
+    "DELETE",
+    "HEAD",
+    "OPTIONS"
+  ]
+  @atom_to_method Enum.zip(@atom_methods, @methods) |> Enum.into(%{})
+
+  @typedoc """
+  An HTTP request method represented as an `atom()` or a `String.t()`.
+
+  The following atom methods are supported: `#{Enum.map_join(@atom_methods, "`, `", &inspect/1)}`.
+  You can use any arbitrary method by providing it as a `String.t()`.
+  """
+  @type method() :: :get | :post | :head | :patch | :delete | :options | :put | String.t()
+
+  @typedoc """
+  A Uniform Resource Locator, the address of a resource on the Web.
+  """
+  @type url() :: String.t() | URI.t()
+
+  @typedoc """
+  Request headers.
+  """
+  @type headers() :: Mint.Types.headers()
+
+  @typedoc """
+  Optional request body.
+  """
+  @type body() :: iodata() | nil
+
+  @type t :: %Finch.Request{}
+
+  @doc false
+  def request_path(%{path: path, query: nil}), do: path
+  def request_path(%{path: path, query: query}), do: "#{path}?#{query}"
+
+  @doc false
+  def build(method, url, headers, body) do
+    {scheme, host, port, path, query} = parse_url(url)
+
+    %Finch.Request{
+      scheme: scheme,
+      host: host,
+      port: port,
+      method: build_method(method),
+      path: path,
+      headers: headers,
+      body: body,
+      query: query
+    }
+  end
+
+  @doc false
+  def parse_url(url) when is_binary(url) do
+    url |> URI.parse() |> parse_url()
+  end
+
+  def parse_url(%URI{} = parsed_uri) do
+    normalize_uri(parsed_uri)
+  end
+
+  defp normalize_uri(parsed_uri) do
+    normalized_path = parsed_uri.path || "/"
+    scheme = normalize_scheme(parsed_uri.scheme)
+    {scheme, parsed_uri.host, parsed_uri.port, normalized_path, parsed_uri.query}
+  end
+
+  defp build_method(method) when is_binary(method), do: method
+  defp build_method(method) when method in @atom_methods, do: @atom_to_method[method]
+
+  defp build_method(method) do
+    supported = Enum.map_join(@atom_methods, ", ", &inspect/1)
+
+    raise ArgumentError, """
+    got unsupported atom method #{inspect(method)}.
+    Only the following methods can be provided as atoms: #{supported}.
+    Otherwise you must pass a binary.
+    """
+  end
+
+  defp normalize_scheme(scheme) do
+    case scheme do
+      "https" ->
+        :https
+
+      "http" ->
+        :http
+
+      scheme ->
+        raise ArgumentError, "invalid scheme #{inspect(scheme)}"
+    end
+  end
+end

--- a/test/finch/http2/integration_test.exs
+++ b/test/finch/http2/integration_test.exs
@@ -12,7 +12,7 @@ defmodule Finch.HTTP2.IntegrationTest do
   end
 
   test "sends http2 requests", %{url: url} do
-    start_supervised({Finch, name: TestFinch, pools: %{
+    start_supervised!({Finch, name: TestFinch, pools: %{
       default: [
         protocol: :http2,
         count: 5,
@@ -24,12 +24,12 @@ defmodule Finch.HTTP2.IntegrationTest do
       ]
     }})
 
-    assert {:ok, response} = Finch.request(TestFinch, :get, url)
+    assert {:ok, response} = Finch.build(:get, url) |> Finch.request(TestFinch)
     assert response.body == "Hello world!"
   end
 
   test "multiplexes requests over a single pool", %{url: url} do
-    start_supervised({Finch, name: TestFinch, pools: %{
+    start_supervised!({Finch, name: TestFinch, pools: %{
       default: [
         protocol: :http2,
         count: 1,
@@ -44,11 +44,13 @@ defmodule Finch.HTTP2.IntegrationTest do
     # We create multiple requests here using a single connection. There is a delay
     # in the response. But because we allow each request to run simultaneously
     # they shouldn't block each other which we check with a rough time estimates
+    request = Finch.build(:get, url <> "/wait/1000")
+
     results =
-      (1..50)
+      (1..1)
       |> Enum.map(fn _ -> Task.async(fn ->
           start = System.monotonic_time()
-          {:ok, _} = Finch.request(TestFinch, :get, url <> "/wait/1000")
+          {:ok, _} = Finch.request(request, TestFinch)
           System.monotonic_time() - start
         end)
       end)

--- a/test/finch/http2/integration_test.exs
+++ b/test/finch/http2/integration_test.exs
@@ -47,7 +47,7 @@ defmodule Finch.HTTP2.IntegrationTest do
     request = Finch.build(:get, url <> "/wait/1000")
 
     results =
-      (1..1)
+      (1..50)
       |> Enum.map(fn _ -> Task.async(fn ->
           start = System.monotonic_time()
           {:ok, _} = Finch.request(request, TestFinch)


### PR DESCRIPTION
Both HTTP1 and HTTP2 already streamed internally,
this PR simply moves the stream out.

This PR also changed the main Finch API to have a
explicit step that builds the request. Instead of:

    Finch.request(MyApp, :get, "/")

You must now do:

    Finch.build(:get, "/") |> Finch.request(MyApp)

This is necessary otherwise the `Finch.stream/5`
API would be very complex. One advantage of this
approach is also that we no longer need to pass
empty headers when configuring get requests, for
example, instead of:

    Finch.request(MyApp, :get, "/", [], nil, pool_timeout: 10_000)

One can now write:

    Finch.build(:get, "/") |> Finch.request(MyApp, pool_timeout: 10_000)

The previous API has been properly deprecated.

Finally, this PR streamlines the `receive_timeout`
value. Previously the documentation and each pool
used a different value.