### PR TITLE
DO NOT MERGE: add information around where the error happened

### DIFF
--- a/lib/finch/http1/conn.ex
+++ b/lib/finch/http1/conn.ex
@@ -45,7 +45,7 @@ defmodule Finch.Conn do
       {:error, error} ->
         meta = Map.put(meta, :error, error)
         Telemetry.stop(:connect, start_time, meta)
-        {:error, conn, error}
+        {:error, conn, :connect, error}
     end
   end
 
@@ -79,7 +79,7 @@ defmodule Finch.Conn do
     end
   end
 
-  def request(%{mint: nil} = conn, _, _, _, _), do: {:error, conn, "Could not connect"}
+  def request(%{mint: nil} = conn, _, _, _, _), do: {:error, conn, :request_mint_nil, "Could not connect"}
 
   def request(conn, req, acc, fun, receive_timeout) do
     full_path = Finch.Request.request_path(req)
@@ -106,13 +106,13 @@ defmodule Finch.Conn do
           {:error, mint, error} ->
             metadata = Map.put(metadata, :error, error)
             Telemetry.stop(:response, start_time, metadata)
-            {:error, %{conn | mint: mint}, error}
+            {:error, %{conn | mint: mint}, :request_receive_response, error}
         end
 
       {:error, mint, error} ->
         metadata = Map.put(metadata, :error, error)
         Telemetry.stop(:request, start_time, metadata)
-        {:error, %{conn | mint: mint}, error}
+        {:error, %{conn | mint: mint}, :request_send_request, error}
     end
   end
 

--- a/lib/finch/http1/pool.ex
+++ b/lib/finch/http1/pool.ex
@@ -43,8 +43,8 @@ defmodule Finch.HTTP1.Pool do
                {:ok, conn, acc} <- Conn.request(conn, req, acc, fun, receive_timeout) do
             {{:ok, acc}, transfer_if_open(conn, from)}
           else
-            {:error, conn, error} ->
-              {{:error, error}, transfer_if_open(conn, from)}
+            {:error, conn, location, error} ->
+              {{:error, location, error}, transfer_if_open(conn, from)}
           end
         end,
         pool_timeout

--- a/test/finch_test.exs
+++ b/test/finch_test.exs
@@ -229,7 +229,7 @@ defmodule FinchTest do
         Plug.Conn.send_resp(conn, 200, "delayed")
       end)
 
-      assert {:error, %{reason: :timeout}} =
+      assert {:error, :request_receive_response, %{reason: :timeout}} =
                Finch.build(:get, endpoint(bypass))
                |> Finch.request(MyFinch, receive_timeout: timeout)
 

--- a/test/finch_test.exs
+++ b/test/finch_test.exs
@@ -241,7 +241,7 @@ defmodule FinchTest do
     test "returns error when requesting bad address" do
       start_supervised!({Finch, name: MyFinch})
 
-      assert {:error, %{reason: :nxdomain}} =
+      assert {:error, :connect, %{reason: :nxdomain}} =
                Finch.build(:get, "http://idontexist.wat") |> Finch.request(MyFinch)
     end
 
@@ -282,7 +282,7 @@ defmodule FinchTest do
         {Finch, name: H2Finch, pools: %{default: [conn_opts: [protocols: [:http2]]]}}
       )
 
-      assert {:error, _} = Finch.build(:get, endpoint(bypass)) |> Finch.request(H2Finch)
+      assert {:error, _, _} = Finch.build(:get, endpoint(bypass)) |> Finch.request(H2Finch)
     end
 
     test "caller is unable to override mode", %{bypass: bypass} do


### PR DESCRIPTION
Temporary branch to help track down `Mint.TransportError: :closed`
