### PR TITLE
Fix finch_test - protocol_not_negotiated

### DIFF
--- a/test/finch/http1/integration_test.exs
+++ b/test/finch/http1/integration_test.exs
@@ -1,0 +1,36 @@
+defmodule Finch.HTTP1.IntegrationTest do
+  use ExUnit.Case, async: false
+  import ExUnit.CaptureLog
+
+  alias Finch.HTTP1Server
+
+  @moduletag :capture_log
+
+  setup_all do
+    port = 4001
+
+    {:ok, _} = HTTP1Server.start(port)
+
+    {:ok, url: "https://localhost:#{port}"}
+  end
+
+  test "fail to negotiate h2 protocol", %{url: url} do
+
+    start_supervised!({Finch, name: H2Finch, pools: %{
+      default: [
+        protocol: :http2,
+        conn_opts: [
+          transport_opts: [
+            verify: :verify_none,
+          ]
+        ]
+      ]
+    }})
+
+    assert capture_log(fn ->
+      {:error, _} = Finch.build(:get, url) |> Finch.request(H2Finch)
+    end) =~ "ALPN protocol not negotiated"
+
+  end
+
+end

--- a/test/finch_test.exs
+++ b/test/finch_test.exs
@@ -278,12 +278,12 @@ defmodule FinchTest do
       stop_supervised(Finch)
     end
 
-    test "SSL - fail to select HTTP2", _bypass do
+    test "fail to negotiate h2 protocol", _bypass do
       start_supervised!({Finch, name: H2Finch, pools: %{default: [protocol: :http2]}})
 
       capture_log(fn ->
         assert {:error, _} = Finch.build(:get, "https://httpstat.us") |> Finch.request(H2Finch)
-      end) =~ "failed to negotiate protocol"
+      end) =~ "ALPN protocol not negotiated"
     end
 
     test "caller is unable to override mode", %{bypass: bypass} do

--- a/test/finch_test.exs
+++ b/test/finch_test.exs
@@ -276,11 +276,13 @@ defmodule FinchTest do
       assert {:ok, _} = Finch.build(:get, endpoint(bypass)) |> Finch.request(H1Finch)
 
       stop_supervised(Finch)
+    end
 
+    test "SSL - fail to select HTTP2", _bypass do
       start_supervised!({Finch, name: H2Finch, pools: %{default: [protocol: :http2]}})
 
       capture_log(fn ->
-        assert {:error, _} = Finch.build(:get, endpoint(bypass)) |> Finch.request(H2Finch)
+        assert {:error, _} = Finch.build(:get, "https://httpstat.us") |> Finch.request(H2Finch)
       end) =~ "failed to negotiate protocol"
     end
 

--- a/test/finch_test.exs
+++ b/test/finch_test.exs
@@ -1,6 +1,5 @@
 defmodule FinchTest do
   use ExUnit.Case, async: true
-  import ExUnit.CaptureLog
   doctest Finch
 
   alias Finch.Response
@@ -276,14 +275,6 @@ defmodule FinchTest do
       assert {:ok, _} = Finch.build(:get, endpoint(bypass)) |> Finch.request(H1Finch)
 
       stop_supervised(Finch)
-    end
-
-    test "fail to negotiate h2 protocol", _bypass do
-      start_supervised!({Finch, name: H2Finch, pools: %{default: [protocol: :http2]}})
-
-      assert capture_log(fn ->
-        {:error, _} = Finch.build(:get, "https://httpstat.us") |> Finch.request(H2Finch)
-      end) =~ "ALPN protocol not negotiated"
     end
 
     test "caller is unable to override mode", %{bypass: bypass} do

--- a/test/finch_test.exs
+++ b/test/finch_test.exs
@@ -281,8 +281,8 @@ defmodule FinchTest do
     test "fail to negotiate h2 protocol", _bypass do
       start_supervised!({Finch, name: H2Finch, pools: %{default: [protocol: :http2]}})
 
-      capture_log(fn ->
-        assert {:error, _} = Finch.build(:get, "https://httpstat.us") |> Finch.request(H2Finch)
+      assert capture_log(fn ->
+        {:error, _} = Finch.build(:get, "https://httpstat.us") |> Finch.request(H2Finch)
       end) =~ "ALPN protocol not negotiated"
     end
 

--- a/test/support/http1_server.ex
+++ b/test/support/http1_server.ex
@@ -1,0 +1,46 @@
+defmodule Finch.HTTP1Server do
+  @moduledoc false
+
+  @fixtures_dir Path.expand("../fixtures", __DIR__)
+
+  def start(port) do
+    children = [
+      Plug.Adapters.Cowboy.child_spec(
+        scheme: :https,
+        plug: Finch.HTTP1Server.PlugRouter,
+        options: [
+          port: port,
+          cipher_suite: :strong,
+          certfile: Path.join([@fixtures_dir, "selfsigned.pem"]),
+          keyfile: Path.join([@fixtures_dir, "selfsigned_key.pem"]),
+          alpn_preferred_protocols: :undefined,
+          otp_app: :finch,
+          protocol_options: [
+            idle_timeout: 3_000,
+            request_timeout: 10_000,
+          ]
+        ]
+      )
+    ]
+
+    Supervisor.start_link(children, strategy: :one_for_one)
+  end
+end
+
+defmodule Finch.HTTP1Server.PlugRouter do
+  @moduledoc false
+
+  use Plug.Router
+
+  plug(:match)
+
+  plug(:dispatch)
+
+  get "/" do
+    name = conn.params["name"] || "world"
+    conn
+    |> send_resp(200, "Hello #{name}!")
+    |> halt()
+  end
+
+end


### PR DESCRIPTION
Hello,

When upgrade Mint from 1.0.0 to 1.1.0, run Finch's tests will get the following error:

```
1) test connection options are passed through to the conn (FinchTest)
     test/finch_test.exs:271
     match (=) failed
     code:  assert {:error, _} = Finch.build(:get, endpoint(bypass)) |> Finch.request(H2Finch)
     left:  {:error, _}
     right: {:ok, %Finch.Response{body: "OK", headers: [{"cache-control", "max-age=0, private, must-revalidate"}, {"content-length", "2"}, {"date", "Thu, 02 Jul 2020 09:06:35 GMT"}, {"server", "Cowboy"}], status: 200}}
     stacktrace:
       test/finch_test.exs:283: anonymous fn/1 in FinchTest."test connection options are passed through to the conn"/1
       (ex_unit 1.10.3) lib/ex_unit/capture_log.ex:74: ExUnit.CaptureLog.capture_log/2
       test/finch_test.exs:282: (test)
```

Since Mint's [commit](https://github.com/elixir-mint/mint/commit/4882d9d8090fa3fd7e45b27141ec60fcf1d488ad) released in 1.1.0 will not support protocol negotiation for TCP connections, Finch's original test case will be break after this upgrade.

I refer Mint's similar [test case](https://github.com/elixir-mint/mint/blob/master/test/mint/integration_test.exs#L32) to modify the above fail test case, its works fine with Mint 1.0.0 and 1.1.0, please review.

Thanks,
Xin