### PR TITLE
Include http method in req and resp metrics

### DIFF
--- a/lib/finch/http1/conn.ex
+++ b/lib/finch/http1/conn.ex
@@ -88,7 +88,8 @@ defmodule Finch.Conn do
       scheme: conn.scheme,
       host: conn.host,
       port: conn.port,
-      path: full_path
+      path: full_path,
+      method: req.method
     }
 
     start_time = Telemetry.start(:request, metadata)

--- a/lib/finch/telemetry.ex
+++ b/lib/finch/telemetry.ex
@@ -78,6 +78,7 @@ defmodule Finch.Telemetry do
     * `:host` - The host address
     * `:port` - the port to connect on.
     * `:path` - The request path.
+    * `:method` - The request method.
 
   * `[:finch, :request, :stop]` - Executed after a request is finished.
 
@@ -89,6 +90,7 @@ defmodule Finch.Telemetry do
     * `:host` - The host address
     * `:port` - the port to connect on.
     * `:path` - The request path.
+    * `:method` - The request method.
     * `:error` - This value is optional. It includes any errors that occured while making the request.
 
   * `[:finch, :response, :start]` - Executed before receiving the response.
@@ -101,6 +103,7 @@ defmodule Finch.Telemetry do
     * `:host` - The host address
     * `:port` - the port to connect on.
     * `:path` - The request path.
+    * `:method` - The request method.
 
   * `[:finch, :response, :stop]` - Executed after a response has been fully received.
 
@@ -112,6 +115,7 @@ defmodule Finch.Telemetry do
     * `:host` - The host address
     * `:port` - the port to connect on.
     * `:path` - The request path.
+    * `:method` - The request method.
     * `:error` - This value is optional. It includes any errors that occured while receiving the response.
 
   * `[:finch, :reused_connection]` - Executed if an existing connection is reused. There are no measurements provided with this event.

--- a/test/finch_test.exs
+++ b/test/finch_test.exs
@@ -431,6 +431,7 @@ defmodule FinchTest do
             assert is_atom(meta.scheme)
             assert is_integer(meta.port)
             assert is_binary(meta.host)
+            assert is_binary(meta.method)
             send(parent, {ref, :start})
 
           [:finch, :request, :stop] ->
@@ -439,6 +440,7 @@ defmodule FinchTest do
             assert is_atom(meta.scheme)
             assert is_integer(meta.port)
             assert is_binary(meta.host)
+            assert is_binary(meta.method)
             send(parent, {ref, :stop})
 
           _ ->
@@ -477,6 +479,7 @@ defmodule FinchTest do
             assert is_atom(meta.scheme)
             assert is_integer(meta.port)
             assert is_binary(meta.host)
+            assert is_binary(meta.method)
             send(parent, {ref, :start})
 
           [:finch, :response, :stop] ->
@@ -485,6 +488,7 @@ defmodule FinchTest do
             assert is_atom(meta.scheme)
             assert is_integer(meta.port)
             assert is_binary(meta.host)
+            assert is_binary(meta.method)
             send(parent, {ref, :stop})
 
           _ ->


### PR DESCRIPTION
So that metrics can be grouped by method where possible.

The method would be an uppercased string, which I think is appropriate for the use case.