### PR TITLE
add request method to h2 telemetry request metric as well

### DIFF
--- a/lib/finch/http2/pool.ex
+++ b/lib/finch/http2/pool.ex
@@ -33,6 +33,7 @@ defmodule Finch.HTTP2.Pool do
       scheme: request.scheme,
       host: request.host,
       port: request.port,
+      method: request.method,
       path: Finch.Request.request_path(request)
     }
 


### PR DESCRIPTION
The previous PR added `:method` to the `:request` Telemetry event, but only for http/1.

I started working on extracting the telemetry tests in finch_test.exs to a new file, and running them for both protocols, which brought to my attention several other inconsistencies. I'll open up a PR later on with that work.