### PR TITLE
Remove transfer code and try peername

### DIFF
--- a/lib/finch/http1/conn.ex
+++ b/lib/finch/http1/conn.ex
@@ -55,7 +55,7 @@ defmodule Finch.Conn do
   def empty_and_open(%{mint: nil}), do: :error
 
   def empty_and_open(conn) do
-    case HTTP.recv(conn.mint, 0, 0) do
+    case HTTP.recv(conn.mint, 0, 5000) do
       {:ok, mint, []} -> {:ok, %{conn | mint: mint}}
       _ -> :error
     end

--- a/lib/finch/http1/pool.ex
+++ b/lib/finch/http1/pool.ex
@@ -78,9 +78,8 @@ defmodule Finch.HTTP1.Pool do
   def handle_checkout(:checkout, _from, conn) do
     idle_time = System.monotonic_time() - conn.last_checkin
 
-    with {:ok, conn} <- Conn.set_mode(conn, :passive) do
-      {:ok, {conn, idle_time}, conn}
-    else
+    case Conn.set_mode(conn, :passive) do
+      {:ok, conn} -> {:ok, {conn, idle_time}, conn}
       _ -> {:remove, :closed}
     end
   end

--- a/lib/finch/http1/pool.ex
+++ b/lib/finch/http1/pool.ex
@@ -78,18 +78,11 @@ defmodule Finch.HTTP1.Pool do
   def handle_checkout(:checkout, _from, conn) do
     idle_time = System.monotonic_time() - conn.last_checkin
 
-    peer =
-      case conn.mint.transport do
-        Mint.Core.Transport.TCP -> :inet.peername(conn.mint.socket)
-        Mint.Core.Transport.SSL -> :ssl.peername(conn.mint.socket)
-      end
-
     with {:ok, conn} <- Conn.set_mode(conn, :passive),
-         {:ok, _} <- peer do
+         {:ok, conn} <- Conn.empty_and_open(conn) do
       {:ok, {conn, idle_time}, conn}
     else
-      {:error, _error} ->
-        {:remove, :closed}
+      _ -> {:remove, :closed}
     end
   end
 


### PR DESCRIPTION
We don't need to transfer if we set the socket to passive mode.

The peername thing is just a guess based on hackney's code.