### PR TITLE
put back NimblePool.checkin

### DIFF
--- a/lib/finch/http1/pool.ex
+++ b/lib/finch/http1/pool.ex
@@ -41,10 +41,10 @@ defmodule Finch.HTTP1.Pool do
 
           with {:ok, conn} <- Conn.connect(conn, from),
                {:ok, conn, acc} <- Conn.request(conn, req, acc, fun, receive_timeout) do
-            {{:ok, acc}, transfer_if_open(conn)}
+            {{:ok, acc}, transfer_if_open(conn, from)}
           else
             {:error, conn, error} ->
-              {{:error, error}, transfer_if_open(conn)}
+              {{:error, error}, transfer_if_open(conn, from)}
           end
         end,
         pool_timeout
@@ -113,8 +113,9 @@ defmodule Finch.HTTP1.Pool do
     {:ok, pool_state}
   end
 
-  defp transfer_if_open(conn) do
+  defp transfer_if_open(conn, from) do
     if Conn.open?(conn) do
+      NimblePool.precheckin(from, conn)
       {:ok, conn}
     else
       :closed


### PR DESCRIPTION
We added the precheckin functionality to NimblePool to address a port leak here: https://github.com/keathley/finch/pull/31 and it was removed here: https://github.com/keathley/finch/pull/71

Unfortunately, without the precheckin, the port leak has returned

/cc @josevalim 