### PR TITLE
HTTP/1 close the connection if the transfer fails

### DIFF
--- a/lib/finch/http1/pool.ex
+++ b/lib/finch/http1/pool.ex
@@ -117,10 +117,14 @@ defmodule Finch.HTTP1.Pool do
     if Conn.open?(conn) do
       if state == :fresh do
         NimblePool.precheckin(from, conn)
-        Conn.transfer(conn, pid)
-      end
 
-      {:ok, conn}
+        case Conn.transfer(conn, pid) do
+          {:ok, conn} -> {:ok, conn}
+          {:error, _, _} -> :closed
+        end
+      else
+        {:ok, conn}
+      end
     else
       :closed
     end


### PR DESCRIPTION
Right now we ignore the return value of `Conn.transfer/2` when we transfer fresh connections to the pool. This is ok, because `Conn.set_mode/2` will fail in `handle_checkin/3`, and the connection will be removed at this point, but with this change, we can skip the attempt to set_mode in cases when we know it will fail.

I don't think this will fix the connection closed error we are tracking down, but this is a bit more efficient than current master in my benchmarks.

/cc @josevalim 