### PR TITLE
Add metadata in connection start event

### DIFF
--- a/lib/finch/http2/pool.ex
+++ b/lib/finch/http2/pool.ex
@@ -143,7 +143,7 @@ defmodule Finch.HTTP2.Pool do
       host: data.host,
       port: data.port,
     }
-    start = Telemetry.start(:connect)
+    start = Telemetry.start(:connect, metadata)
     case HTTP2.connect(data.scheme, data.host, data.port, data.connect_opts) do
       {:ok, conn} ->
         Telemetry.stop(:connect, start, metadata)


### PR DESCRIPTION
This PR adds metadata to the connection start event. This is going to be improved in some upcoming PRs. But it seemed like this was a useful fix to get out now.