### PR TITLE
Use HTTP1 in HTTP1 pools

### DIFF
--- a/lib/finch/http1/conn.ex
+++ b/lib/finch/http1/conn.ex
@@ -68,11 +68,13 @@ defmodule Finch.Conn do
     end
   end
 
-  def stream(%{mint: nil}, _), do: {:error, "Connection is dead"}
+  def discard(%{mint: nil}, _), do: :unknown
 
-  def stream(conn, message) do
-    with {:ok, mint, responses} <- HTTP1.stream(conn.mint, message) do
-      {:ok, %{conn | mint: mint}, responses}
+  def discard(conn, message) do
+    case HTTP1.stream(conn.mint, message) do
+      {:ok, mint, _responses} -> {:ok, %{conn | mint: mint}}
+      {:error, _, reason, _} -> {:error, reason}
+      :unknown -> :unknown
     end
   end
 

--- a/lib/finch/http1/pool.ex
+++ b/lib/finch/http1/pool.ex
@@ -97,10 +97,9 @@ defmodule Finch.HTTP1.Pool do
 
   @impl NimblePool
   def handle_info(message, conn) do
-    case Conn.stream(conn, message) do
-      {:ok, conn, _} -> {:ok, conn}
+    case Conn.discard(conn, message) do
+      {:ok, conn} -> {:ok, conn}
       :unknown -> {:ok, conn}
-      {:error, _mint, _error, _responses} -> {:remove, :closed}
       {:error, _error} -> {:remove, :closed}
     end
   end


### PR DESCRIPTION
Otherwise Mint may try HTTP2 if available.