### PR TITLE
Introduce max_idle_time for HTTP1 connections

### DIFF
--- a/lib/finch.ex
+++ b/lib/finch.ex
@@ -28,6 +28,12 @@ defmodule Finch do
       doc: "Number of pools to start.",
       default: @default_pool_count
     ],
+    max_idle_time: [
+      type: :timeout,
+      doc:
+        "The maxiumum number of milliseconds an HTTP1 connection is allowed to be idle before being closed during a checkout attempt",
+      default: :infinity
+    ],
     conn_opts: [
       type: :keyword_list,
       doc:
@@ -135,7 +141,8 @@ defmodule Finch do
       size: valid[:size],
       count: valid[:count],
       conn_opts: valid[:conn_opts],
-      protocol: valid[:protocol]
+      protocol: valid[:protocol],
+      max_idle_time: valid[:max_idle_time]
     }
   end
 

--- a/lib/finch/http1/conn.ex
+++ b/lib/finch/http1/conn.ex
@@ -12,6 +12,7 @@ defmodule Finch.Conn do
       opts: opts.conn_opts,
       parent: parent,
       last_checkin: System.monotonic_time(),
+      max_idle_time: opts.max_idle_time,
       mint: nil
     }
   end
@@ -60,6 +61,16 @@ defmodule Finch.Conn do
 
   def open?(%{mint: nil}), do: false
   def open?(%{mint: mint}), do: HTTP1.open?(mint)
+
+  def idle_time(conn, unit \\ :native) do
+    idle_time = System.monotonic_time() - conn.last_checkin
+
+    System.convert_time_unit(idle_time, :native, unit)
+  end
+
+  def reusable?(conn) do
+    idle_time(conn, :millisecond) < conn.max_idle_time
+  end
 
   def set_mode(conn, mode) when mode in [:active, :passive] do
     case HTTP1.set_mode(conn.mint, mode) do

--- a/lib/finch/http1/conn.ex
+++ b/lib/finch/http1/conn.ex
@@ -68,6 +68,8 @@ defmodule Finch.Conn do
     System.convert_time_unit(idle_time, :native, unit)
   end
 
+  def reusable?(%{max_idle_time: :infinity}), do: true
+
   def reusable?(conn) do
     idle_time(conn, :millisecond) < conn.max_idle_time
   end

--- a/lib/finch/http1/pool.ex
+++ b/lib/finch/http1/pool.ex
@@ -71,16 +71,17 @@ defmodule Finch.HTTP1.Pool do
 
   @impl NimblePool
   def handle_checkout(:checkout, _, %{mint: nil} = conn, pool_state) do
-    idle_time = System.monotonic_time() - conn.last_checkin
-    {:ok, {:fresh, conn, idle_time}, conn, pool_state}
+    {:ok, {:fresh, conn, Conn.idle_time(conn)}, conn, pool_state}
   end
 
   def handle_checkout(:checkout, _from, conn, pool_state) do
-    idle_time = System.monotonic_time() - conn.last_checkin
-
-    case Conn.set_mode(conn, :passive) do
-      {:ok, conn} -> {:ok, {:reuse, conn, idle_time}, conn, pool_state}
-      _ -> {:remove, :closed, pool_state}
+    with true <- Conn.reusable?(conn),
+         {:ok, conn} <- Conn.set_mode(conn, :passive) do
+      {:ok, {:reuse, conn, Conn.idle_time(conn)}, conn, pool_state}
+    else
+      _ ->
+        Conn.close(conn)
+        {:remove, :closed, pool_state}
     end
   end
 


### PR DESCRIPTION
@keathley as we discussed yesterday on IRC, this PR adds an optional `max_idle_time` pool configuration. This change allows us to deal with misbehaving endpoints that do not close connections cleanly. Before this change, we were seeing `{:error, %Mint.TransportError{reason: :closed}}` when Finch attempted to reuse connections that had not been cleanly closed.

After this commit, the user can specify a `max_idle_time` in milliseconds and, when checking out an existing connection, the pool will verify that the current idle time is less than this specified time. If it is greater, the pool will close the Mint connection and remove the worker from the pool.

This change should be backwards compatible as the default `max_idle_time` is `:infinity`.

We weren't sure how to add ex_unit tests for this change, nor if this option should have any effect on the HTTP2 pool. However, we have verified that deploying this change into our QA environment does indeed solve the problem we were previously seeing.

We also tested the change locally via iptables. To induce this misbehavior, you can run any kind of simple HTTP server locally (let's suppose it's on port 4000) and use this type of iptables rule to drop FIN packets from that server, which simulates a remote endpoint that does not cleanly close connections, leaving a stale connection in the Finch pool.

```
iptables -A INPUT --protocol tcp --source-port 4000 --tcp-flags FIN FIN -j DROP
```

Steps to reproduce:

1. Run a test HTTP endpoint locally, and use iptables to block FIN packets from that server (see above)
2. Configure Finch with a pool size of 1 to guarantee we hit the stale connection in the next steps
3. Make one request to the test HTTP server through Finch
4. Wait 60+ seconds for the remote endpoint to time out the idle connection (you can verify a stream of FINs are attempted to be sent by the server via tcpdump, etc.)
5. Make a new request through the Finch pool. You will see `{:error, %Mint.TransportError{reason: :closed}}`.

Thanks!
Drew and Mike

Signed-off-by: Mike Pilat <mike.pilat@greensill.com>