### PR TITLE
Revert "Use lifo strategy to improve connection reuse"

### DIFF
--- a/lib/finch.ex
+++ b/lib/finch.ex
@@ -20,22 +20,12 @@ defmodule Finch do
     ],
     size: [
       type: :pos_integer,
-      doc: """
-      Number of connections to maintain in each pool. Used only by HTTP1 pools \
-      since HTTP2 is able to multiplex requests through a single connection. In \
-      other words, for HTTP2, the size is always 1.
-      """,
+      doc: "Number of connections to maintain in each pool.",
       default: @default_pool_size
     ],
     count: [
       type: :pos_integer,
-      doc: """
-      Number of pools to start. HTTP1 pools are able to re-use connections in the \
-      same pool and establish new ones only when necessary. However, if there is a \
-      high pool count and few requests are made, these requests will be scattered \
-      across pools, reducing connection reuse. It is recommended to increase the pool \
-      count for HTTP1 only if you are experiencing high checkout times.
-      """,
+      doc: "Number of pools to start.",
       default: @default_pool_count
     ],
     max_idle_time: [

--- a/lib/finch/http1/pool.ex
+++ b/lib/finch/http1/pool.ex
@@ -14,11 +14,8 @@ defmodule Finch.HTTP1.Pool do
   end
 
   def start_link({shp, registry_name, pool_size, conn_opts}) do
-    NimblePool.start_link(
-      worker: {__MODULE__, {registry_name, shp, conn_opts}},
-      pool_size: pool_size,
-      strategy: :lifo
-    )
+    opts = [worker: {__MODULE__, {registry_name, shp, conn_opts}}, pool_size: pool_size]
+    NimblePool.start_link(opts)
   end
 
   @impl Finch.Pool

--- a/mix.exs
+++ b/mix.exs
@@ -34,7 +34,7 @@ defmodule Finch.MixProject do
     [
       {:mint, "~> 1.2"},
       {:castore, "~> 0.1.5"},
-      {:nimble_pool, "~> 0.2.2"},
+      {:nimble_pool, "~> 0.2.1"},
       {:nimble_options, "~> 0.3"},
       {:telemetry, "~> 0.4"},
       {:ex_doc, "~> 0.21", only: :dev, runtime: false},


### PR DESCRIPTION
Reverts keathley/finch#93

These changes greatly improved things in the test scenario that I came up with to reliably reproduce the connection closed errors, but when I deployed them to production I actually saw the error rate increase 😦 .

We are continuing to investigate another strategy.