### PR TITLE
Retry requests if the connection is closed when we make a request

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,0 +1,3 @@
+import Config
+
+import_config "#{config_env()}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,0 +1,7 @@
+import Config
+
+config :logger,
+  level: :debug,
+  handle_sasl_reports: true,
+  handle_otp_repots: true
+

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,2 @@
+import Config
+

--- a/lib/finch.ex
+++ b/lib/finch.ex
@@ -237,9 +237,7 @@ defmodule Finch do
   end
 
   def request(name, method, url, headers, body \\ nil, opts \\ []) do
-    IO.warn("Finch.request/6 is deprecated, use Finch.build/4 + Finch.request/3 instead")
-
-    build(method, url, headers, body)
-    |> request(name, opts)
+    req = build(method, url, headers, body)
+    request(req, name, opts)
   end
 end

--- a/lib/finch/http1/conn.ex
+++ b/lib/finch/http1/conn.ex
@@ -17,6 +17,10 @@ defmodule Finch.Conn do
     }
   end
 
+  def reset(conn) do
+    %{conn | mint: nil}
+  end
+
   def connect(%{mint: mint} = conn) when not is_nil(mint) do
     meta = %{
       scheme: conn.scheme,


### PR DESCRIPTION
There's a race condition where we can make a request and the server can close the tcp connection at the same time. When this happens we see a connection closed error. I was able to reproduce this behavior by running a local apache server with the following keep alive settings:

```
KeepAlive On
KeepAliveTimeout 1
MaxKeepAliveRequests 100
```

I then ran the following in iex:

```elixir
Finch.start_link(name: TestPool, pools: %{"http://localhost:8080" => [size: 1, count: 1, protocol: :http1]})
for i <- 0..100 do
  :timer.sleep(1000)
  Finch.request(TestPool, :get, "http://localhost:8080")
end
```

Using this I was able to determine that we were, in fact, hitting this race condition. If we delay the next request even slightly then the connection waits longer in the pool and we receive the tcp connection closed message in the inbox and correctly clean up the connection. I ran a packet capture which further verified this behaviour.

The solution here is to check if a request returns a closed error. If it does we attempt to re-open the connection and re-issue the request. This _should_ be a safe operation but it still feels...scary. All of this happens in the caller process, which means we could starve the pool if this happens a lot. But, I'm more comfortable with that then forcing a new checkout to happen.

I don't believe that this is the only issue