### PR TITLE
Reduce runtime time unit conversions

### DIFF
--- a/lib/finch.ex
+++ b/lib/finch.ex
@@ -152,9 +152,12 @@ defmodule Finch do
       count: valid[:count],
       conn_opts: valid[:conn_opts],
       protocol: valid[:protocol],
-      max_idle_time: valid[:max_idle_time]
+      max_idle_time: to_native(valid[:max_idle_time])
     }
   end
+
+  defp to_native(:infinity), do: :infinity
+  defp to_native(time), do: System.convert_time_unit(time, :millisecond, :native)
 
   defp supervisor_name(name), do: :"#{name}.Supervisor"
   defp manager_name(name), do: :"#{name}.PoolManager"

--- a/lib/finch/http1/conn.ex
+++ b/lib/finch/http1/conn.ex
@@ -71,7 +71,7 @@ defmodule Finch.Conn do
     System.convert_time_unit(idle_time, :native, unit)
   end
 
-  def reusable?(%{max_idle_time: :infinity}, idle_time), do: true
+  def reusable?(%{max_idle_time: :infinity}, _idle_time), do: true
   def reusable?(%{max_idle_time: max_idle_time}, idle_time), do: idle_time <= max_idle_time
 
   def set_mode(conn, mode) when mode in [:active, :passive] do

--- a/lib/finch/http1/conn.ex
+++ b/lib/finch/http1/conn.ex
@@ -71,11 +71,8 @@ defmodule Finch.Conn do
     System.convert_time_unit(idle_time, :native, unit)
   end
 
-  def reusable?(%{max_idle_time: :infinity}), do: true
-
-  def reusable?(conn) do
-    idle_time(conn, :millisecond) < conn.max_idle_time
-  end
+  def reusable?(%{max_idle_time: :infinity}, idle_time), do: true
+  def reusable?(%{max_idle_time: max_idle_time}, idle_time), do: idle_time <= max_idle_time
 
   def set_mode(conn, mode) when mode in [:active, :passive] do
     case HTTP1.set_mode(conn.mint, mode) do

--- a/lib/finch/http1/pool.ex
+++ b/lib/finch/http1/pool.ex
@@ -74,17 +74,18 @@ defmodule Finch.HTTP1.Pool do
 
   @impl NimblePool
   def handle_checkout(:checkout, _, %{mint: nil} = conn, pool_state) do
-    {:ok, {:fresh, conn, Conn.idle_time(conn)}, conn, pool_state}
+    idle_time = System.monotonic_time() - conn.last_checkin
+    {:ok, {:fresh, conn, idle_time}, conn, pool_state}
   end
 
   def handle_checkout(:checkout, _from, conn, pool_state) do
-    with true <- Conn.reusable?(conn),
+    idle_time = System.monotonic_time() - conn.last_checkin
+
+    with true <- Conn.reusable?(conn, idle_time),
          {:ok, conn} <- Conn.set_mode(conn, :passive) do
-      {:ok, {:reuse, conn, Conn.idle_time(conn)}, conn, pool_state}
+      {:ok, {:reuse, conn, idle_time}, conn, pool_state}
     else
-      _ ->
-        Conn.close(conn)
-        {:remove, :closed, pool_state}
+      _ -> {:remove, :closed, pool_state}
     end
   end
 


### PR DESCRIPTION
Convert max_idle_time to native on init to
avoid doing conversions at runtime.

Also compute idle_time only once.