### PR TITLE
Initial implementation of streaming request

### DIFF
--- a/lib/finch.ex
+++ b/lib/finch.ex
@@ -168,8 +168,7 @@ defmodule Finch do
 
   When making HTTP/1.x requests, it is possible to send the request body in a streaming fashion.
   In order to do so, the `body` parameter needs to take form of a tuple `{:stream, body_stream}`,
-  where `body_stream` is a [Stream](https://hexdocs.pm/elixir/Stream.html). This functionality
-  is not yet supported for HTTP/2 requests.
+  where `body_stream` is a `Stream` is not yet supported for HTTP/2 requests.
   """
   @spec build(Request.method(), Request.url(), Request.headers(), Request.body()) :: Request.t()
   defdelegate build(method, url, headers \\ [], body \\ nil), to: Request

--- a/lib/finch.ex
+++ b/lib/finch.ex
@@ -168,7 +168,7 @@ defmodule Finch do
 
   When making HTTP/1.x requests, it is possible to send the request body in a streaming fashion.
   In order to do so, the `body` parameter needs to take form of a tuple `{:stream, body_stream}`,
-  where `body_stream` is a `Stream` is not yet supported for HTTP/2 requests.
+  where `body_stream` is a `Stream`. This feature is not yet supported for HTTP/2 requests.
   """
   @spec build(Request.method(), Request.url(), Request.headers(), Request.body()) :: Request.t()
   defdelegate build(method, url, headers \\ [], body \\ nil), to: Request

--- a/lib/finch.ex
+++ b/lib/finch.ex
@@ -165,6 +165,11 @@ defmodule Finch do
 
   @doc """
   Builds an HTTP request to be sent with `request/3` or `stream/4`.
+
+  When making HTTP/1.x requests, it is possible to send request body in a streaming fashion.
+  In order to do so, the `body` parameter needs to take form of a tuple `{:stream, body_stream}`,
+  where `body_stream` is a [Stream](https://hexdocs.pm/elixir/Stream.html). This functionality
+  is not yet supported for HTTP/2 requests.
   """
   @spec build(Request.method(), Request.url(), Request.headers(), Request.body()) :: Request.t()
   defdelegate build(method, url, headers \\ [], body \\ nil), to: Request

--- a/lib/finch.ex
+++ b/lib/finch.ex
@@ -166,7 +166,7 @@ defmodule Finch do
   @doc """
   Builds an HTTP request to be sent with `request/3` or `stream/4`.
 
-  When making HTTP/1.x requests, it is possible to send request body in a streaming fashion.
+  When making HTTP/1.x requests, it is possible to send the request body in a streaming fashion.
   In order to do so, the `body` parameter needs to take form of a tuple `{:stream, body_stream}`,
   where `body_stream` is a [Stream](https://hexdocs.pm/elixir/Stream.html). This functionality
   is not yet supported for HTTP/2 requests.

--- a/lib/finch/request.ex
+++ b/lib/finch/request.ex
@@ -47,7 +47,7 @@ defmodule Finch.Request do
   @typedoc """
   Optional request body.
   """
-  @type body() :: iodata() | nil
+  @type body() :: iodata() | {:stream, Enumerable.t()} | nil
 
   @type t :: %Finch.Request{}
 

--- a/test/finch_test.exs
+++ b/test/finch_test.exs
@@ -668,6 +668,57 @@ defmodule FinchTest do
                Finch.build(:get, endpoint(bypass, "?" <> query_string))
                |> Finch.stream(MyFinch, acc, fun)
     end
+
+    test "successful post request, with query string and string request body", %{bypass: bypass} do
+      start_supervised!({Finch, name: MyFinch})
+      query_string = "query=value"
+      req_headers = [{"content-type", "application/json"}]
+      req_body = "{hello:\"world\"}"
+      resp_body = "{hi:\"there\"}"
+
+      Bypass.expect_once(bypass, "POST", "/", fn conn ->
+        assert conn.query_string == query_string
+        Plug.Conn.send_resp(conn, 200, resp_body)
+      end)
+
+      acc = {nil, [], ""}
+
+      fun = fn
+        {:status, value}, {_, headers, body} -> {value, headers, body}
+        {:headers, value}, {status, headers, body} -> {status, headers ++ value, body}
+        {:data, value}, {status, headers, body} -> {status, headers, body <> value}
+      end
+
+      assert {:ok, {200, [_ | _], ^resp_body}} =
+               Finch.build(:post, endpoint(bypass, "?" <> query_string), req_headers, req_body)
+               |> Finch.stream(MyFinch, acc, fun)
+    end
+
+    test "successful post request, with query string and streaming request body", %{bypass: bypass} do
+      start_supervised!({Finch, name: MyFinch})
+      query_string = "query=value"
+      req_headers = [{"content-type", "application/json"}]
+      req_stream = Stream.map(1..10_000, fn(_) -> "please" end)
+      req_body = req_stream |> Enum.join("")
+      resp_body = "{hi:\"there\"}"
+
+      Bypass.expect_once(bypass, "POST", "/", fn conn ->
+        assert conn.query_string == query_string
+        Plug.Conn.send_resp(conn, 200, resp_body)
+      end)
+
+      acc = {nil, [], ""}
+
+      fun = fn
+        {:status, value}, {_, headers, body} -> {value, headers, body}
+        {:headers, value}, {status, headers, body} -> {status, headers ++ value, body}
+        {:data, value}, {status, headers, body} -> {status, headers, body <> value}
+      end
+
+      assert {:ok, {200, [_ | _], ^resp_body}} =
+               Finch.build(:post, endpoint(bypass, "?" <> query_string), req_headers, {:stream, req_stream})
+               |> Finch.stream(MyFinch, acc, fun)
+    end
   end
 
   defp get_pools(name, shp) do

--- a/test/finch_test.exs
+++ b/test/finch_test.exs
@@ -699,7 +699,6 @@ defmodule FinchTest do
       query_string = "query=value"
       req_headers = [{"content-type", "application/json"}]
       req_stream = Stream.map(1..10_000, fn(_) -> "please" end)
-      req_body = req_stream |> Enum.join("")
       resp_body = "{hi:\"there\"}"
 
       Bypass.expect_once(bypass, "POST", "/", fn conn ->


### PR DESCRIPTION
This provides support for streaming request body with Elixir streams and Enumerable.reduce like @josevalim suggested.

I have tested this with fairly large files and it doesn't seem to be having any negative effect on memory with or without wrapping the streaming of body into Task.

@sneako suggested we *don't* do Task to to wrap streaming request body. @josevalim suggested we'd better wrap the whole operation in a process if we want to control the timeout on streaming request body.  Here is the conversation for reference: https://elixirforum.com/t/memory-leak-binaries-that-only-recon-bin-leak-1-helps-with/35804/10

I am, however, getting to conclusion that maybe we should *not* be handling that directly in Finch, and instead have a `timeout` parameter on [Mint.HTTP.stream_request_body/3](https://hexdocs.pm/mint/Mint.HTTP.html#stream_request_body/3). This is so we are consistent with what we do on both sending and receiving sides. Mint accepts a `timeout` option when receiving the payload, or establishing a connection, but does *not* accept a timeout option when sending payload to the server (or making a request in general), or streaming.

I think what we should be doing on Finch and other higher-level clients is to appropriately handle splitting / calculating overall and individual timeouts per chunks of data we send, but add option to Mint itself to have timeout option available when we send data to server. So, we'd add the option [here](https://github.com/elixir-mint/mint/blob/v1.2.0/lib/mint/http1.ex#L290), maybe also [here](https://github.com/elixir-mint/mint/blob/v1.2.0/lib/mint/http1.ex#L231) and then to appropriate transport, in our case http1 so places like [here](https://github.com/elixir-mint/mint/blob/v1.2.0/lib/mint/core/transport/tcp.ex#L50) and several other places.

So I suggest we don't try to solve this in Finch now, instead build building blocks for easily solving it in Mint, and then come back to improve the library with timeout options on sending request payload.

There is a problem here, however, in that `:gen_tcp` does *not* support timeout on send either. So this would have to be entirely contained within Mint I think.

There is also option to play with `send_timeout`, which I think defaults to something like 3 hours:

```
send(Socket, Packet) -> ok | {error, Reason}
Types:
Socket = socket()
Packet = iodata()
Reason = inet:posix()

Sends a packet on a socket.

There is no send call with timeout option, you use the send_timeout socket option if timeouts are desired. See the examples section.
```

```
The fact that the send call does not accept a timeout option, is because timeouts on send is handled through the socket option send_timeout. The behavior of a send operation with no receiver is in a very high degree defined by the underlying TCP stack, as well as the network infrastructure. If one wants to write code that handles a hanging receiver that might eventually cause the sender to hang on a send call, one writes code like the following.
Consider a process that receives data from a client process that is to be forwarded to a server on the network. The process has connected to the server via TCP/IP and does not get any acknowledge for each message it sends, but has to rely on the send timeout option to detect that the other end is unresponsive. We could use the send_timeout option when connecting:

...
{ok,Sock} = gen_tcp:connect(HostAddress, Port,
                            [{active,false},
                             {send_timeout, 5000},
                             {packet,2}]),
                loop(Sock), % See below
...
```

If we want to do it, however, entirely in Finch, then I don't see problem with using Task / spawned process that streams the data from it. According to my tests it works just fine.

What do you folks think?