### PR TITLE
Fix formatting

### DIFF
--- a/lib/finch/telemetry.ex
+++ b/lib/finch/telemetry.ex
@@ -6,7 +6,7 @@ defmodule Finch.Telemetry do
 
   Finch executes the following events:
 
-    * `[:finch, :queue, :start]` - Executed before checking out a connection from the pool.
+  * `[:finch, :queue, :start]` - Executed before checking out a connection from the pool.
 
     #### Measurements
 


### PR DESCRIPTION
The current indentation makes the rendered documentation look like:

![image](https://user-images.githubusercontent.com/865203/102379051-74aaea80-3f94-11eb-808b-cd0f3b1aaec7.png)

The fix will make the first section look like the others. 

---


I verified it using an online markdown renderer:

With the fix:

![image](https://user-images.githubusercontent.com/865203/102379366-ce131980-3f94-11eb-9a0a-f3d350c41a36.png)

Without the fix: 

![image](https://user-images.githubusercontent.com/865203/102379451-db300880-3f94-11eb-8ae3-1310786de353.png)
