### PR TITLE
Fix incorrect stream/5 typespec

### DIFF
--- a/lib/finch.ex
+++ b/lib/finch.ex
@@ -196,7 +196,7 @@ defmodule Finch do
       Default value is `15_000`.
 
   """
-  @spec stream(Request.t(), name(), acc, stream(acc), keyword) :: acc when acc: term()
+  @spec stream(Request.t(), name(), acc, stream(acc), keyword) :: {:ok, acc} when acc: term()
   def stream(%Request{} = req, name, acc, fun, opts \\ []) when is_function(fun, 2) do
     %{scheme: scheme, host: host, port: port} = req
     {pool, pool_mod} = PoolManager.get_pool(name, {scheme, host, port})


### PR DESCRIPTION
Hello!

I was using `stream/5` in a project today and noticed that the typespec appears to be incorrect. Currently `stream/5`'s [spec says it's return type is acc](https://github.com/keathley/finch/blob/v0.6.0/lib/finch.ex#L199). However, when using `stream/5` it returned `{:ok, acc}` instead. This appears to be confirmed in [existing Finch tests](https://github.com/keathley/finch/blob/v0.6.0/test/finch_test.exs#L667) for `stream/5`.

This PR updates the `stream/5` typespec to be `{:ok, acc}`. If I've missed something, please feel free to decline this PR and let me know!