### PR TITLE
Add correct transport_opt flags to all pools

### DIFF
--- a/lib/finch/http1/conn.ex
+++ b/lib/finch/http1/conn.ex
@@ -39,13 +39,7 @@ defmodule Finch.Conn do
 
     # We have to use Mint's top-level connect function or else proxying won't work. So we
     # force the connection to use http1 and call it in this roundabout way.
-    default_transport_opts = [
-      keepalive: true,
-      nodelay: true,
-    ]
     conn_opts = Keyword.merge(conn.opts, mode: :passive, protocols: [:http1])
-    transport_opts = Keyword.merge(default_transport_opts, conn_opts[:transport_opts] || [])
-    conn_opts = Keyword.put(conn_opts, :transport_opts, transport_opts)
 
     case Mint.HTTP.connect(conn.scheme, conn.host, conn.port, conn_opts) do
       {:ok, mint} ->

--- a/lib/finch/http1/conn.ex
+++ b/lib/finch/http1/conn.ex
@@ -39,7 +39,13 @@ defmodule Finch.Conn do
 
     # We have to use Mint's top-level connect function or else proxying won't work. So we
     # force the connection to use http1 and call it in this roundabout way.
+    default_transport_opts = [
+      keepalive: true,
+      nodelay: true,
+    ]
     conn_opts = Keyword.merge(conn.opts, mode: :passive, protocols: [:http1])
+    transport_opts = Keyword.merge(default_transport_opts, conn_opts[:transport_opts] || [])
+    conn_opts = Keyword.put(conn_opts, :transport_opts, transport_opts)
 
     case Mint.HTTP.connect(conn.scheme, conn.host, conn.port, conn_opts) do
       {:ok, mint} ->

--- a/mix.exs
+++ b/mix.exs
@@ -40,7 +40,7 @@ defmodule Finch.MixProject do
       {:telemetry, "~> 0.4"},
       {:ex_doc, "~> 0.21", only: :dev, runtime: false},
       {:credo, "~> 1.3", only: [:dev, :test]},
-      {:dialyxir, "~> 1.0", only: [:dev, :test]},
+      {:dialyxir, "~> 1.0", only: [:dev, :test], runtime: false},
       {:bypass, "~> 1.0", only: :test},
       {:cowboy, "~> 2.0", only: [:dev, :test]},
       {:plug_cowboy, "~> 2.0", only: [:dev, :test]},


### PR DESCRIPTION
I believe that this PR finally resolves the connection closed issues described in #62 and elsewhere. We've continued to see this issue in production. I added these flags to our pool configuration in production and we haven't seen a single issue for the past several hours. Based on the descriptions of the `keepalive` flag itself, I suspect we'll dramatically reduce the connection closed issues we've seen with finch.

As part of this fix I also defaulted the connect time to something much more reasonable (30 seconds is really way too high for a default) and enabled tcp nodelay. Everyone I know who has tuned http enables that flag (including us) so it makes sense to just set it as a default.

Lemme know what you think.