### PR TITLE
Return url in cast error

### DIFF
--- a/lib/finch.ex
+++ b/lib/finch.ex
@@ -133,7 +133,7 @@ defmodule Finch do
         cast_binary_destination(url)
 
       _ ->
-        {:error, %ArgumentError{message: "invalid destination"}}
+        {:error, %ArgumentError{message: "invalid destination: #{inspect destination}"}}
     end
   end
 

--- a/lib/finch/request.ex
+++ b/lib/finch/request.ex
@@ -77,12 +77,22 @@ defmodule Finch.Request do
   end
 
   def parse_url(%URI{} = parsed_uri) do
-    normalize_uri(parsed_uri)
-  end
-
-  defp normalize_uri(parsed_uri) do
     normalized_path = parsed_uri.path || "/"
-    scheme = normalize_scheme(parsed_uri.scheme)
+
+    scheme = case parsed_uri.scheme do
+      "https" ->
+        :https
+
+      "http" ->
+        :http
+
+      nil ->
+        raise ArgumentError, "scheme is required for url: #{URI.to_string(parsed_uri)}"
+
+      scheme ->
+        raise ArgumentError, "invalid scheme \"#{scheme}\" for url: #{URI.to_string(parsed_uri)}"
+    end
+
     {scheme, parsed_uri.host, parsed_uri.port, normalized_path, parsed_uri.query}
   end
 
@@ -97,18 +107,5 @@ defmodule Finch.Request do
     Only the following methods can be provided as atoms: #{supported}.
     Otherwise you must pass a binary.
     """
-  end
-
-  defp normalize_scheme(scheme) do
-    case scheme do
-      "https" ->
-        :https
-
-      "http" ->
-        :http
-
-      scheme ->
-        raise ArgumentError, "invalid scheme #{inspect(scheme)}"
-    end
   end
 end

--- a/test/finch_test.exs
+++ b/test/finch_test.exs
@@ -75,7 +75,7 @@ defmodule FinchTest do
     end
 
     test "pools with an invalid URL cannot be started" do
-      assert_raise(ArgumentError, ~r/invalid scheme nil/, fn ->
+      assert_raise(ArgumentError, ~r/scheme is required for url: example.com/, fn ->
         Finch.start_link(
           name: MyFinch,
           pools: %{
@@ -84,7 +84,7 @@ defmodule FinchTest do
         )
       end)
 
-      assert_raise(ArgumentError, ~r/invalid scheme nil/, fn ->
+      assert_raise(ArgumentError, ~r/scheme is required for url: example/, fn ->
         Finch.start_link(
           name: MyFinch,
           pools: %{
@@ -93,7 +93,7 @@ defmodule FinchTest do
         )
       end)
 
-      assert_raise(ArgumentError, ~r/invalid scheme nil/, fn ->
+      assert_raise(ArgumentError, ~r/scheme is required for url: :443/, fn ->
         Finch.start_link(
           name: MyFinch,
           pools: %{
@@ -135,7 +135,7 @@ defmodule FinchTest do
     end
 
     test "raises when requesting a URL with an invalid scheme" do
-      assert_raise ArgumentError, ~r"invalid scheme \"ftp\"", fn ->
+      assert_raise ArgumentError, ~r"invalid scheme \"ftp\" for url: ftp://example.com", fn ->
         Finch.build(:get, "ftp://example.com")
       end
     end


### PR DESCRIPTION
We had an issue the other day where a URL was malformed slightly. It was very hard to figure out what was failing and why. Adding a little more information to this error makes it much more obvious what is going wrong.