### PR TITLE
Stop appending empty query to path

### DIFF
--- a/lib/finch/request.ex
+++ b/lib/finch/request.ex
@@ -53,6 +53,7 @@ defmodule Finch.Request do
 
   @doc false
   def request_path(%{path: path, query: nil}), do: path
+  def request_path(%{path: path, query: ""}), do: path
   def request_path(%{path: path, query: query}), do: "#{path}?#{query}"
 
   @doc false


### PR DESCRIPTION
If I pass a request object with `query: ""`, I end up with a needless "?" appended to the path. I think `request_path/1` should also check for query being empty string. What do you think?