### PR TITLE
Demonitor process when request is done

### DIFF
--- a/lib/finch/http2/pool.ex
+++ b/lib/finch/http2/pool.ex
@@ -81,12 +81,15 @@ defmodule Finch.HTTP2.Pool do
         response_waiting_loop(fun.({kind, value}, acc), fun, ref, monitor_ref, fail_safe_timeout)
 
       {:done, _ref} ->
+        Process.demonitor(monitor_ref)
         {:ok, acc}
 
       {:error, ^ref, error} ->
+        Process.demonitor(monitor_ref)
         {:error, error}
     after
       fail_safe_timeout ->
+        Process.demonitor(monitor_ref)
         raise "no response was received even after waiting #{fail_safe_timeout}ms. " <>
                 "This is likely a bug in Finch, but we're raising so that your system doesn't " <>
                 "get stuck in an infinite receive."


### PR DESCRIPTION
We don't demonitor the http connection when making http/2 requests. We need to do this in order to avoid memory leaks and build up of useless monitors.